### PR TITLE
Header: Fix deprecated error

### DIFF
--- a/inc/serverX.h
+++ b/inc/serverX.h
@@ -25,6 +25,7 @@
 
 // feature test macro requirements
 
+#define _DEFAULT_SOURCE
 #define _GNU_SOURCE
 #define _BSD_SOURCE
 #define _XOPEN_SOURCE 700

--- a/inc/winserverX.h
+++ b/inc/winserverX.h
@@ -22,6 +22,7 @@
 
 // feature test macro requirements
 
+#define _DEFAULT_SOURCE
 #define _GNU_SOURCE
 #define _BSD_SOURCE
 #define _XOPEN_SOURCE 700


### PR DESCRIPTION
I was having this error in archlinux

```
$ make
gcc -ggdb3 -O0 -O3 -std=c11 -Wall -Werror -Wextra -Wno-sign-compare -Wshadow -U__STRICT_ANSI__ -Iinc -c src/urldecode.c -o bin/urldecode.o
In file included from /usr/include/getopt.h:24:0,
                 from inc/serverX.h:46,
                 from src/urldecode.c:21:
/usr/include/features.h:183:3: error: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Werror=cpp]
 # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
   ^~~~~~~
cc1: todos los avisos se tratan como errores
make: *** [Makefile:66: bin/urldecode.o] Error 1
```