### PR TITLE
Handle: Finish the program more correctly

### DIFF
--- a/src/handler.c
+++ b/src/handler.c
@@ -20,15 +20,11 @@
 // include header
 #include <serverX.h>
 
-// global variables
-
-extern bool signaled;
-
 /**
  * Handles signals.
  */
 void handler(int signal)
 {
     // control-c
-    if (signal == SIGINT)    signaled = true;
+    stop();
 }

--- a/src/main.c
+++ b/src/main.c
@@ -26,9 +26,6 @@ char* root = NULL;
 // file descriptor for sockets
 int cfd = -1, sfd = -1;
 
-// flag indicating whether control-c has been heard
-bool signaled = false;
-
 int main(int argc, char* argv[])
 {
     // a global variable defined in errno.h that's "set by system
@@ -85,9 +82,6 @@ int main(int argc, char* argv[])
             close(cfd);
             cfd = -1;
         }
-
-        // check for control-c
-        if (signaled)    stop();
 
         // check whether client has connected
         if (connected()) {

--- a/src/stop.c
+++ b/src/stop.c
@@ -45,5 +45,5 @@ void stop(void)
     if (sfd != -1)    close(sfd);
 
     // stop server
-    exit(errsv);
+    pthread_exit(0);
 }


### PR DESCRIPTION
I have removed the signaled global, and now the server ends with pthread_exit.

Fixes #16